### PR TITLE
Enhance Editor with undo/redo and indentation

### DIFF
--- a/beautiful_rich_text_editor.html
+++ b/beautiful_rich_text_editor.html
@@ -18,6 +18,8 @@
         <div id="editorjs"></div>
 
         <div class="buttons-container">
+            <button id="undo-btn" class="btn btn-secondary">↩️ Undo</button>
+            <button id="redo-btn" class="btn btn-secondary">↪️ Redo</button>
             <button id="save-btn" class="btn btn-primary">
                 💾 Save Content
             </button>

--- a/js/config.js
+++ b/js/config.js
@@ -132,7 +132,7 @@ export const EDITOR_CONFIG = {
 };
 
 export const UI_CONFIG = {
-  debounceTime: 500,
+  debounceTime: 100,
   maxHistorySize: 50,
   autoSaveInterval: 30000 // 30 seconds
 };

--- a/js/undo-redo.js
+++ b/js/undo-redo.js
@@ -31,16 +31,17 @@ export class UndoRedoManager {
     }, 1000);
 
     // Listen to editor changes
+    const editorElement = document.getElementById('editorjs');
+
     if (this.editor.config && typeof this.editor.config.onChange === 'function') {
       // Editor already has onChange handler, we need to create a manual listener
-      document.getElementById('editorjs').addEventListener('input', () => {
+      editorElement.addEventListener('input', () => {
         if (!this.isUndoRedoing) {
           this.handleChange();
         }
       });
     } else {
       // Setup a mutation observer to detect changes
-      const editorElement = document.getElementById('editorjs');
       if (editorElement) {
         const observer = new MutationObserver(() => {
           if (!this.isUndoRedoing) {
@@ -55,6 +56,25 @@ export class UndoRedoManager {
           attributes: true
         });
       }
+    }
+
+    if (editorElement) {
+      editorElement.addEventListener('keydown', (event) => {
+        if (event.key === 'Tab') {
+          event.preventDefault();
+          if (event.shiftKey) {
+            document.execCommand('outdent');
+          } else {
+            document.execCommand('indent');
+          }
+          if (!this.isUndoRedoing) {
+            this.handleChange();
+          }
+        } else if (!this.isUndoRedoing && (event.key === ' ' || event.key === 'Enter')) {
+          this.saveState();
+          this.lastSaveTime = Date.now();
+        }
+      });
     }
 
     // Setup keyboard shortcuts


### PR DESCRIPTION
## Summary
- add Undo/Redo buttons in the rich editor demo
- save history when space/enter pressed and handle Tab indentation
- lower undo-redo debounce to catch smaller edits

## Testing
- `node --check js/undo-redo.js`
- `node --check js/config.js`


------
https://chatgpt.com/codex/tasks/task_e_688728c147f08322a09b2441f3205740