### PR TITLE
Enable word-level undo/redo and new toolbar buttons

### DIFF
--- a/beautiful_rich_text_editor.html
+++ b/beautiful_rich_text_editor.html
@@ -21,6 +21,12 @@
             <button id="save-btn" class="btn btn-primary">
                 💾 Save Content
             </button>
+            <button id="undo-btn" class="btn btn-secondary">
+                ↩️ Undo
+            </button>
+            <button id="redo-btn" class="btn btn-secondary">
+                ↪️ Redo
+            </button>
             <button id="clear-btn" class="btn btn-secondary">
                 🗑️ Clear All
             </button>

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 // Main application initialization
 
 import {EditorManager} from './editor-manager.js';
-// import {UIHandlers} from './ui-handlers.js';
+import {UIHandlers} from './ui-handlers.js';
 import {updateStatus} from './utils.js';
 
 class App {
@@ -37,7 +37,7 @@ class App {
       // Initialize the editor with a small delay
       setTimeout(async () => {
         await this.editorManager.initialize();
-        //this.uiHandlers = new UIHandlers(this.editorManager);
+        this.uiHandlers = new UIHandlers(this.editorManager);
         console.log('Application started successfully');
       }, 500);
 

--- a/js/config.js
+++ b/js/config.js
@@ -20,7 +20,8 @@ export const EDITOR_CONFIG = {
       class: EditorjsList,
       inlineToolbar: true,
       config: {
-        defaultStyle: 'unordered'
+        defaultStyle: 'unordered',
+        maxNestingLevel: 5
       }
     },
 
@@ -132,7 +133,8 @@ export const EDITOR_CONFIG = {
 };
 
 export const UI_CONFIG = {
-  debounceTime: 500,
+  // Save history more frequently to track word by word changes
+  debounceTime: 100,
   maxHistorySize: 50,
   autoSaveInterval: 30000 // 30 seconds
 };

--- a/js/ui-handlers.js
+++ b/js/ui-handlers.js
@@ -32,6 +32,16 @@ export class UIHandlers {
       this.handleExport();
     });
 
+    // Undo button
+    document.getElementById('undo-btn')?.addEventListener('click', () => {
+      this.editorManager.undoRedoManager?.undo();
+    });
+
+    // Redo button
+    document.getElementById('redo-btn')?.addEventListener('click', () => {
+      this.editorManager.undoRedoManager?.redo();
+    });
+
     // Import button
     document.getElementById('import-btn')?.addEventListener('click', () => {
       this.handleImport();

--- a/js/undo-redo.js
+++ b/js/undo-redo.js
@@ -33,9 +33,16 @@ export class UndoRedoManager {
     // Listen to editor changes
     if (this.editor.config && typeof this.editor.config.onChange === 'function') {
       // Editor already has onChange handler, we need to create a manual listener
-      document.getElementById('editorjs').addEventListener('input', () => {
+      const editorEl = document.getElementById('editorjs');
+      editorEl.addEventListener('input', () => {
         if (!this.isUndoRedoing) {
           this.handleChange();
+        }
+      });
+      // Save state after each word delimiter for finer undo history
+      editorEl.addEventListener('keydown', (event) => {
+        if (!this.isUndoRedoing && (event.key === ' ' || event.key === 'Enter')) {
+          this.saveState();
         }
       });
     } else {
@@ -53,6 +60,13 @@ export class UndoRedoManager {
           subtree: true,
           characterData: true,
           attributes: true
+        });
+
+        // Save state when user finishes a word
+        editorElement.addEventListener('keydown', (event) => {
+          if (!this.isUndoRedoing && (event.key === ' ' || event.key === 'Enter')) {
+            this.saveState();
+          }
         });
       }
     }


### PR DESCRIPTION
## Summary
- enable UI handlers and add undo/redo buttons
- track history at word level
- expose undo/redo controls via buttons
- allow deeper list nesting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688728c147f08322a09b2441f3205740