### PR TITLE
Fix undo manager and add copy/paste shortcuts

### DIFF
--- a/keyboardShortcuts.js
+++ b/keyboardShortcuts.js
@@ -1,29 +1,47 @@
-document.addEventListener('keydown', function(e) {
+document.addEventListener('keydown', function (e) {
   // Check for Ctrl or Cmd
   const ctrl = e.ctrlKey || e.metaKey;
   if (!ctrl) return;
 
   // Prevent default for handled shortcuts
   let handled = false;
+  const key = e.key.toLowerCase();
 
   // Bold: Ctrl+B
-  if (e.key.toLowerCase() === 'b') {
+  if (key === 'b') {
     handled = true;
-    // Assuming editorjs instance is available as `editor`
     editor.blocks.insert('paragraph', { text: '<b></b>' });
   }
 
   // Italic: Ctrl+I
-  if (e.key.toLowerCase() === 'i') {
+  if (key === 'i') {
     handled = true;
     editor.blocks.insert('paragraph', { text: '<i></i>' });
   }
 
   // Headings: Ctrl+1/2/3 for H1/H2/H3
-  if (['1', '2', '3'].includes(e.key)) {
+  if (['1', '2', '3'].includes(key)) {
     handled = true;
-    const level = parseInt(e.key);
+    const level = parseInt(key);
     editor.blocks.insert('header', { text: '', level });
+  }
+
+  // Copy/Cut/Paste shortcuts
+  if (key === 'c') {
+    handled = true;
+    document.execCommand('copy');
+  } else if (key === 'x') {
+    handled = true;
+    document.execCommand('cut');
+  } else if (key === 'v') {
+    handled = true;
+    // allow default paste behaviour
+  } else if (!e.shiftKey && key === 'z') {
+    handled = true;
+    editor.undoRedoManager?.undo();
+  } else if ((e.shiftKey && key === 'z') || key === 'y') {
+    handled = true;
+    editor.undoRedoManager?.redo();
   }
 
   if (handled) e.preventDefault();


### PR DESCRIPTION
## Summary
- repair syntax error in undo-redo.js
- register paste events and track changes
- update keyboard shortcut handler to include copy, cut, paste, undo and redo

## Testing
- `node --check js/undo-redo.js`
- `node --check keyboardShortcuts.js`


------
https://chatgpt.com/codex/tasks/task_e_68873f0d6dd08322acfead733362e0db